### PR TITLE
Respect Content API Options that are set

### DIFF
--- a/HiddenFoundry.ContentDeliveryApi.ExpandContentAreas/ExpandContentAreaCollectionProperty.cs
+++ b/HiddenFoundry.ContentDeliveryApi.ExpandContentAreas/ExpandContentAreaCollectionProperty.cs
@@ -47,15 +47,15 @@ public class ExpandContentAreaCollectionProperty : CollectionPropertyModelBase<C
         {
             ExtendedContentApiOptions newOptions = new ExtendedContentApiOptions();
             var recursiveContentAreaOptions = ServiceLocator.Current.GetInstance<IOptions<ContentAreaExpandOptions>>();
-            newOptions.recursiveLevelsRemaining = recursiveContentAreaOptions.Value.MaxExpandContentAreaLevels;
+            newOptions.RecursiveLevelsRemaining = recursiveContentAreaOptions.Value.MaxExpandContentAreaLevels;
 
             _converterContext = GetConverterContextClone(_converterContext, newOptions);
         }
 
         var extendedOptions = _converterContext.Options as ExtendedContentApiOptions;
-        if (extendedOptions != null && extendedOptions.recursiveLevelsRemaining > 0)
+        if (extendedOptions != null && extendedOptions.RecursiveLevelsRemaining > 0)
         {
-            extendedOptions.recursiveLevelsRemaining--;
+            extendedOptions.RecursiveLevelsRemaining--;
 
             // Create new ConverterContext to pass into next iteration. We don't want to pass a reference as we want to persist the recursiveLevelsRemaining separately along each branch
 
@@ -117,7 +117,7 @@ public class ExpandContentAreaCollectionProperty : CollectionPropertyModelBase<C
 
     public class ExtendedContentApiOptions : EPiServer.ContentApi.Core.Configuration.ContentApiOptions, ICloneable
     {
-        public int recursiveLevelsRemaining { get; set; }
+        public int RecursiveLevelsRemaining { get; set; }
 
         public object Clone()
         {

--- a/HiddenFoundry.ContentDeliveryApi.ExpandContentAreas/ExpandContentAreaCollectionProperty.cs
+++ b/HiddenFoundry.ContentDeliveryApi.ExpandContentAreas/ExpandContentAreaCollectionProperty.cs
@@ -1,4 +1,5 @@
 ﻿using EPiServer;
+using EPiServer.ContentApi.Core.Configuration;
 using EPiServer.ContentApi.Core.Serialization;
 using EPiServer.ContentApi.Core.Serialization.Models;
 using EPiServer.Core;
@@ -45,8 +46,12 @@ public class ExpandContentAreaCollectionProperty : CollectionPropertyModelBase<C
         // If first time processing a content area then get the recursion value to keep tracking max iterations.
         if (_converterContext.Options is not ExtendedContentApiOptions)
         {
-            ExtendedContentApiOptions newOptions = new ExtendedContentApiOptions();
+            var contentApiOptions = ServiceLocator.Current.GetInstance<IOptions<ContentApiOptions>>();
+
+            var newOptions = new ExtendedContentApiOptions(contentApiOptions.Value);
+
             var recursiveContentAreaOptions = ServiceLocator.Current.GetInstance<IOptions<ContentAreaExpandOptions>>();
+
             newOptions.RecursiveLevelsRemaining = recursiveContentAreaOptions.Value.MaxExpandContentAreaLevels;
 
             _converterContext = GetConverterContextClone(_converterContext, newOptions);
@@ -117,6 +122,25 @@ public class ExpandContentAreaCollectionProperty : CollectionPropertyModelBase<C
 
     public class ExtendedContentApiOptions : EPiServer.ContentApi.Core.Configuration.ContentApiOptions, ICloneable
     {
+        public ExtendedContentApiOptions(ContentApiOptions contentApiOptions)
+        {
+            //When updating CD API, remember to keep this in sync if any new props are added
+
+            EnablePreviewFeatures = contentApiOptions.EnablePreviewFeatures;
+            EnablePreviewMode = contentApiOptions.EnablePreviewMode;
+            ExpandedBehavior = contentApiOptions.ExpandedBehavior;
+            ForceAbsolute = contentApiOptions.ForceAbsolute;
+            IncludeEmptyContentProperties = contentApiOptions.IncludeEmptyContentProperties;
+            IncludeMasterLanguage = contentApiOptions.IncludeMasterLanguage;
+            IncludeNumericContentIdentifier = contentApiOptions.IncludeNumericContentIdentifier;
+            MultiSiteFilteringEnabled = contentApiOptions.MultiSiteFilteringEnabled;
+            ValidateTemplateForContentUrl = contentApiOptions.ValidateTemplateForContentUrl;
+            FlattenPropertyModel = contentApiOptions.FlattenPropertyModel;
+            IncludeInternalContentRoots = contentApiOptions.IncludeInternalContentRoots;
+            IncludeSiteHosts = contentApiOptions.IncludeSiteHosts;
+            HttpResponseExpireTime = contentApiOptions.HttpResponseExpireTime;
+        }
+
         public int RecursiveLevelsRemaining { get; set; }
 
         public object Clone()


### PR DESCRIPTION
This change is to respect any content api options that were set when adding the Content Delivery API, such as "FlattenPropertyModel". 

It can cause inconsistencies in the response when "FlattenPropertyModel" for instance is enabled and works normally, but when this nuget package kicks in and starts expanding content areas and ignores "FlattenPropertyModel" - This means content areas nested deeper in the response can look different than the ones before it. 